### PR TITLE
Use all jails when -T is given but -j is not

### DIFF
--- a/portest
+++ b/portest
@@ -343,8 +343,6 @@ if [ "${USE_POUDRIERE}" == "YES" ] && [ "${TEST_BUILD}" -eq "1" ]; then
 		POUDRIERE_JAILS=`poudriere  jail -l -n | grep -v "JAILNAME"`
 	fi
 	
-	POUDRIERE_JAILS=`pr
-	intf "%s\n" ${POUDRIERE_JAILS} | sort -u`
 	for jail in ${POUDRIERE_JAILS}; do
 	${POUDRIERE} jail -i -j $jail >/dev/null 2>&1
 	[ $? -ne 0 ] && echo "No such jail $jail" && exit 1

--- a/portest
+++ b/portest
@@ -339,10 +339,11 @@ if [ "${USE_POUDRIERE}" == "YES" ] && [ "${TEST_BUILD}" -eq "1" ]; then
 	
 	# if no jails were set with -j use all jails for testing
 	if [ -z "${POUDRIERE_JAILS}" ]; then
-		echo "no jails selected; using all" 
+		echo "no jails selected; using all existing jails" 
 		POUDRIERE_JAILS=`poudriere  jail -l -n | grep -v "JAILNAME"`
 	fi
 	
+	POUDRIERE_JAILS=`printf "%s\n" ${POUDRIERE_JAILS} | sort -u`
 	for jail in ${POUDRIERE_JAILS}; do
 	${POUDRIERE} jail -i -j $jail >/dev/null 2>&1
 	[ $? -ne 0 ] && echo "No such jail $jail" && exit 1

--- a/portest
+++ b/portest
@@ -334,9 +334,17 @@ done
 
 # Check for valid jails #
 if [ "${USE_POUDRIERE}" == "YES" ] && [ "${TEST_BUILD}" -eq "1" ]; then
+
 	check_command "${POUDRIERE}" "Try installing it, pkg install poudriere"
-	[ -z "${POUDRIERE_JAILS}" ] && echo "no jails selected use -j or export POUDRIERE_JAILS=\"jail1 jail2\"" && exit 1
-	POUDRIERE_JAILS=`printf "%s\n" ${POUDRIERE_JAILS} | sort -u`
+	
+	# if no jails were set with -j use all jails for testing
+	if [ -z "${POUDRIERE_JAILS}" ]; then
+		echo "no jails selected; using all" 
+		POUDRIERE_JAILS=`poudriere  jail -l -n | grep -v "JAILNAME"`
+	fi
+	
+	POUDRIERE_JAILS=`pr
+	intf "%s\n" ${POUDRIERE_JAILS} | sort -u`
 	for jail in ${POUDRIERE_JAILS}; do
 	${POUDRIERE} jail -i -j $jail >/dev/null 2>&1
 	[ $? -ne 0 ] && echo "No such jail $jail" && exit 1


### PR DESCRIPTION
Hello Ricky,

since i have a special machine just for poudriere testing its a little bit nasty to always define the jails to use. Especially when the jails changes. ;)

Therefore this little patch: it will use all jails stored in poudriere when testing is wanted but no jail is defined. This should integrate smoothly into a testing-workflow for new versions of FreeBSD, because less maintenance is needed. :)

Greetings,
Torsten
